### PR TITLE
Start accepting pull requests and update license

### DIFF
--- a/.github/pull_request_template.txt
+++ b/.github/pull_request_template.txt
@@ -1,2 +1,3 @@
-We are sorry but we don't accept pull requests.
-Please read <https://github.com/fujitsu/compiler-test-suite/blob/main/README.md>.
+This PR includes the following changes to the Compiler Test Suite:
+ - Brief description of the changes
+ - (Details of added or modified test cases)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Compiler Test Suite
+
+Thank you for your interest in contributing to **Fujitsu Compiler-Test-Suite**!  
+This repository provides a collection of test cases for compiler validation.  
+Currently maintained under [fujitsu/compiler-test-suite](https://github.com/fujitsu/compiler-test-suite), this project is planned to be integrated into the LLVM project in the future.
+
+## Contribution Workflow
+
+1. **Fork and branch**
+   - Fork this repository and create a feature branch from `main`.
+   - Use a descriptive branch name, e.g., `fix-math-tests` or `add-loop-optimization-cases`.
+
+2. **Make your changes**
+   - Add new test cases or improve existing ones.
+   - Keep tests minimal, self-contained, and clearly targeted at a specific compiler feature or bug.  
+
+3. **Run checks locally**
+   - Ensure that your contribution does not break existing tests.
+   - Provide clear instructions if your test requires special setup.
+   - Make sure that the expected results of your tests are clear and understandable.
+
+4. **Submit a Pull Request**
+   - Open a Pull Request (PR) against the `main` branch.
+   - Clearly describe:
+     - Purpose of the change
+     - Category of tests (e.g., C, C++, Fortran, optimization, diagnostics)
+     - Any references to standards or specifications
+
+## Code of Conduct
+
+This project follows the principles of the [LLVM Community Code of Conduct](https://llvm.org/docs/CodeOfConduct.html).  
+Please be respectful and constructive in all interactions.
+
+## Licensing
+
+- As of accepting external contributions, this repository uses the **Apache License v2.0 with LLVM Exceptions**, identical to the LLVM project’s license.  
+- By submitting a contribution, you agree that your code and test cases will be distributed under these terms.  
+
+## Developer Certificate of Origin (DCO) / Contributor License Agreement (CLA)
+
+- Similar to LLVM project, this project **does not require DCO or CLA** for contributions.  
+- Contributors retain the copyright to their submitted code.  
+- However, all contributions must comply with the repository license terms (Apache License v2.0 with LLVM Exceptions).  
+- **Do not include code copied or derived from other programs or projects**, unless it is clearly permitted by the license and explicitly documented. All contributions must be original work suitable for upstreaming to LLVM test-suite.
+
+## Future Migration to LLVM
+
+- This repository is intended to be integrated into the LLVM project(LLVM test-suite) in the future.  
+- Once migration occurs, contributions will follow the **[LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html)** and other official LLVM contribution guidelines.  
+- Contributors should keep this in mind when preparing test cases (e.g., style, scope, and relevance).
+
+## Questions / Support
+
+- Open a GitHub Issue for discussion before submitting large or controversial changes. Suggestions and proposals are also welcome.  
+- For general LLVM-related questions, refer to the [LLVM community resources](https://llvm.org/docs/).
+  

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,11 +1,14 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
 
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   1. Definitions.
+    1. Definitions.
 
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
@@ -64,14 +67,14 @@
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
+    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       copyright license to reproduce, prepare Derivative Works of,
       publicly display, publicly perform, sublicense, and distribute the
       Work and such Derivative Works in Source or Object form.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
+    3. Grant of Patent License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       (except as stated in this section) patent license to make, have made,
@@ -87,7 +90,7 @@
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
 
-   4. Redistribution. You may reproduce and distribute copies of the
+    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
@@ -128,7 +131,7 @@
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
+    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
       this License, without any additional terms or conditions.
@@ -136,12 +139,12 @@
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
 
-   6. Trademarks. This License does not grant permission to use the trade
+    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
+    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
@@ -151,7 +154,7 @@
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
-   8. Limitation of Liability. In no event and under no legal theory,
+    8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
@@ -163,7 +166,7 @@
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
+    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
@@ -174,9 +177,9 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-   END OF TERMS AND CONDITIONS
+    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
+    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
@@ -187,16 +190,89 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+    Copyright 2025 Fujitsu Limited
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,50 @@
-Fujitsu Compiler Test Suite
-===========================
+# Fujitsu Compiler Test Suite
+
 
 This repository contains a test suite for C/C++/Fortran compilers developed by Fujitsu.
 
-This test suite was originally developed for the proprietary Fujitsu C/C++/Fortran compilers. We Fujitsu would like to contribute it to [the LLVM community](https://llvm.org/) to advance the quality of Clang/Flang/LLVM. The LLVM community has [its own test suite](https://github.com/llvm/llvm-test-suite/). We plan to join this effort, but it may take time to have consensus in the community on how to integrate. To make the community able to reach our test suite early, we release it in this repository as "Fujitsu Compiler Test Suite".
+This test suite was originally developed for the proprietary Fujitsu C/C++/Fortran compilers. We would like to contribute it to [the LLVM community](https://llvm.org/) to advance the quality of Clang/Flang/LLVM. The LLVM community has [its own test suite](https://github.com/llvm/llvm-test-suite/). We plan to join this effort, but it may take time to have consensus in the community on how to integrate. To make the community able to reach our test suite early, we release it in this repository as "Fujitsu Compiler Test Suite".
 
-Target Platform
----------------
+## Target Platform
 
 Most test programs in this test suite will be able to run on many platforms (OS/CPU). However, because it was originally developed for Fujitsu C/C++/Fortran compilers, which target Linux/AArch64, it may contain test programs which don't run on platforms other than Linux/AArch64.
 
-How to Use
-----------
+## How to Use
 
 Please read [RUN.md](RUN.md) to use this test suite.
 
-Known Issues
-------------
+## Known Issues
 
 Please see [KnownIssues Wiki page](https://github.com/fujitsu/compiler-test-suite/wiki/KnownIssues) for known issues.
 
-License
--------
+## License
 
-The Fujitsu Compiler Test Suite is licensed under [the Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). It is slightly different from the one used in [the LLVM Project](https://github.com/llvm/llvm-project/) and [the LLVM test-suite](https://github.com/llvm/llvm-test-suite/) ([Apache License v2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT)) for internal reasons.
+From the August 2025 release, the Fujitsu Compiler Test Suite is licensed under [the Apache License, Version 2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT), the same license as used in [the LLVM Project](https://github.com/llvm/llvm-project/). This change was made in anticipation of future integration with LLVM test-suite.
 
-Contact
--------
 
-email: contact-compiler-test-suite@cs.jp.fujitsu.com
+## Contribution
 
-Contribution
-------------
+[Bug reports are welcome](https://github.com/fujitsu/compiler-test-suite/issues).
 
-[Bug reports are welcome](https://github.com/fujitsu/compiler-test-suite/issues/new).
+From the August 2025 release, this test suite has started accepting pull requests. All contributions will be accepted under the same license as the LLVM project: [Apache License Version 2.0 with LLVM Exceptions](https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT).
 
-We are sorry but we don't accept pull requests. As explained above, we plan to join the LLVM test-suite in the future, but the license is different. We'll switch the license when we join. To make it easy, we want to hold copyright of whole test suite. If you have any suggestions, please let us know them as [issues](https://github.com/fujitsu/compiler-test-suite/issues/new).
+Note: We are considering integrating this test suite into the [LLVM test-suite](https://github.com/llvm/llvm-test-suite) in the future. Please contribute only if you agree with this policy.
 
-Current Status
---------------
+For details about contributing, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+
+## Known Issues and Future Plans
 
 As of the 2025-08 release, the Fujitsu Compiler Test Suite lacks following things. They will be available in the upcoming releases.
 
-- More test programs for C/C++/Fortran
+- Addition of C/C++/Fortran test programs
 - Many missing reference output files (used to verify outputs from test programs)
+- Some tests have excessively long execution times
+- Some tests consume large amounts of disk space
+
+
+## Contact
+For general communication, suggestions, or proposals, please open an issue on GitHub.  
+If local/private communication is required, please contact us by email:  
+contact-compiler-test-suite@cs.jp.fujitsu.com
+


### PR DESCRIPTION
This PR updates the documentation to reflect the start of accepting external pull requests and the change of license to Apache License v2.0 with LLVM Exceptions.

README.md:
Announced PR acceptance, updated license information, clarified future integration policy with LLVM test-suite.

CONTRIBUTING.md:
Fixed incomplete sentence, added reference to LLVM community resources. These changes ensure that all contributions are compatible with future migration to the LLVM project.

LICENSE.TXT:
Updated to reflect the new license. These changes ensure that all contributions are compatible with future migration to the LLVM project.