### PR TITLE
Testset fixes based on LLVM-2208 and 16779

### DIFF
--- a/C++/0032/0032_1052.cc
+++ b/C++/0032/0032_1052.cc
@@ -28,16 +28,10 @@ int main()
 	X x(23);
 	x.X::~X();
 
-	if( x.i == 0 ) count++;
-            else printf("ng x.i : %d \n", x.i);
-	if( x.b.i == 0 ) count++;
-            else printf("ng x.b.i : %d \n", x.b.i);
 	if( A_124p23::dtor == 1 ) count++;
             else printf("ng A_124p23::dtor : %d \n", A_124p23::dtor);
 	if( B_124p23::dtor == 1 ) count++;
             else printf("ng B_124p23::dtor : %d \n", B_124p23::dtor);
 
-        if( count == 4 ) printf("ok\n");
+        if( count == 2 ) printf("ok\n");
 }
-
-


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and WorkItem 16779.
https://linaro.atlassian.net/browse/LLVM-2208

The details of the correction are as follows.
Since it is possible to determine whether the destructor is called within the program by checking the updates to the variable `dtor`, the checks for "x.i" and "x.b.i" will be removed.
