### PR TITLE
Remove untested `0979_0003.output_reference`

### DIFF
--- a/Fortran/0979/0979_0003.reference_output
+++ b/Fortran/0979/0979_0003.reference_output
@@ -1,2 +1,0 @@
- pass
-exit 0


### PR DESCRIPTION
Remove test Fortran/0979/0979_0003, which has `.reference_output` file but no corresponding test program.