### PR TITLE
Testset fixes based on LLVM-2211 and Workitem 17223

### DIFF
--- a/Fortran/0683/0683_0101.f90
+++ b/Fortran/0683/0683_0101.f90
@@ -34,7 +34,7 @@ program main
      a(i) = data(mod(i,5)+1)
   end do
   call sub(a, n)
-  if (abs(ss-result) < 5.0) then
+  if (abs(ss-result) < 6.0) then
      print *, "PASS"
   else
      print *, ss, abs(ss-result)

--- a/Fortran/0683/CMakeLists.txt
+++ b/Fortran/0683/CMakeLists.txt
@@ -1,2 +1,4 @@
 llvm_singlesource_fujitsu(PREFIX "Fujitsu-Fortran-")
 llvm_set_own_fortran_module_directory()
+set_property(SOURCE 0683_0101.f90 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-0683_0101 APPEND PROPERTY LINK_OPTIONS "-fopenmp")


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17223".
  https://linaro.atlassian.net/browse/LLVM-2211

Specifically, I make the following two corrections.
・To verify OpenMP SIMD reduction, which is the original objective, specify the -fopenmp option.
・Due to vectorization, a difference of 3 ULP in the real part and 5 ULP in the imaginary part has arisen in the single-precision complex multiplication. In this test, the size of the complex difference is calculated as abs(ss - result), but the current threshold of 5.0 does not allow for a complex difference of 5.8309517. To allow for rounding errors of approximately 5 ULP as complex differences, the threshold will be relaxed from 5.0 to 6.0.
