### PR TITLE
Testset fixes based on LLVM-2214 and Workitem 17297

### DIFF
--- a/Fortran/0162/0162_0024.f90
+++ b/Fortran/0162/0162_0024.f90
@@ -1,6 +1,6 @@
 ip=100
 ip2=100
-!$omp parallel do default(none) private(ip,ip2) 
+!$omp parallel do default(none) shared(ip2) 
     DO ip = 0, 1
 ip2=10000
     DO ip2 = 0, 1

--- a/Fortran/0165/0165_0026.f90
+++ b/Fortran/0165/0165_0026.f90
@@ -1,4 +1,4 @@
-         !$omp parallel do default(none) collapse(3) private(i, j, j1, j2) 
+         !$omp parallel do default(none) collapse(3) private(j2)
          do i=1,1
            do j=1,1
            do j1=1,1

--- a/Fortran/0165/0165_0027.f90
+++ b/Fortran/0165/0165_0027.f90
@@ -1,4 +1,4 @@
-         !$omp parallel do default(none) collapse(4) private(i, j, j1, j2)
+         !$omp parallel do default(none) collapse(4) private(j2)
          do i=1,1
            do j=1,1
            do j1=1,1

--- a/Fortran/0165/0165_0028.f90
+++ b/Fortran/0165/0165_0028.f90
@@ -1,7 +1,7 @@
 i=10
 j=20
 k=30
-         !$omp parallel do default(none) collapse(3) private(i,jk)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0029.f90
+++ b/Fortran/0165/0165_0029.f90
@@ -2,8 +2,7 @@ i=10
 j=20
 k=30
          !$omp task default(none)
-!        !$omp parallel do default(none) collapse(3) private(i) shared(j)
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1
@@ -20,8 +19,7 @@ i=10
 j=20
 k=30
          !$omp task default(none)
-!        !$omp parallel default(none) private(i) shared(j)
-         !$omp parallel default(none) private(i,j,k)
+         !$omp parallel default(none) private(i)
          !$omp do collapse(3)
          do i=1,1
            do j=1,1

--- a/Fortran/0165/0165_0030.f90
+++ b/Fortran/0165/0165_0030.f90
@@ -3,8 +3,7 @@ j=20
 k=30
          !$omp task default(none)
          !$omp task
-!        !$omp parallel do default(none) collapse(3) private(i) shared(j)
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1
@@ -23,8 +22,7 @@ j=20
 k=30
          !$omp task default(none)
          !$omp task 
-!        !$omp parallel default(none) private(i) shared(j)
-         !$omp parallel default(none) private(i,j,k)
+         !$omp parallel default(none) private(i)
          !$omp do collapse(3)
          do i=1,1
            do j=1,1

--- a/Fortran/0165/0165_0031.f90
+++ b/Fortran/0165/0165_0031.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel 
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0032.f90
+++ b/Fortran/0165/0165_0032.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(shared)
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0033.f90
+++ b/Fortran/0165/0165_0033.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(none) private(i,j,k)
-         !$omp parallel do default(none) collapse(3) private(i,j,k) 
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0034.f90
+++ b/Fortran/0165/0165_0034.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel reduction (+:i,j,k)
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0035.f90
+++ b/Fortran/0165/0165_0035.f90
@@ -1,11 +1,11 @@
 i=10
 j=20
 k=30
-         !$omp parallel do default(none) collapse(3) private(i,j,k) shared(i1,j1,k1)
+         !$omp parallel do default(none) collapse(3) private(i) shared(i1,j1,k1)
          do i=1,1
            do j=1,1
            do k=1,1
-         !$omp parallel do default(none) collapse(3) private(i1,j1,k1) 
+         !$omp parallel do default(none) collapse(3) private(i1)
          do i1=1,1
            do j1=1,1
            do k1=1,1
@@ -25,11 +25,11 @@ if (k.ne.30) print *,'err',k
 i=10
 j=20
 k=30
-         !$omp parallel do default(none) collapse(3) private(i,j,k) shared(i1,j1,k1)
+         !$omp parallel do default(none) collapse(3) private(i) shared(i1,j1,k1)
          do i=1,1
            do j=1,1
            do k=1,1
-         !$omp parallel default(none) private(i1,j1,k1) 
+         !$omp parallel default(none) private(i1) shared(j1)
          !$omp do collapse(3)
          do i1=1,1
            do j1=1,1

--- a/Fortran/0165/0165_0036.f90
+++ b/Fortran/0165/0165_0036.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(firstprivate)
-         !$omp parallel do default(none) collapse(3) private(i,j,k)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0037.f90
+++ b/Fortran/0165/0165_0037.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel 
-         !$omp parallel do default(private) collapse(3) private(i,j,k) 
+         !$omp parallel do default(private) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0038.f90
+++ b/Fortran/0165/0165_0038.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel 
-         !$omp parallel do default(firstprivate) collapse(3) private(i,j,k)
+         !$omp parallel do default(firstprivate) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0039.f90
+++ b/Fortran/0165/0165_0039.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(shared)
-         !$omp parallel do default(shared) collapse(3) private(i,j,k) 
+         !$omp parallel do default(shared) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0040.f90
+++ b/Fortran/0165/0165_0040.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(none) private(i,j,k)
-         !$omp parallel do default(private) collapse(3_1) private(i,j,k) 
+         !$omp parallel do default(private) collapse(3_1) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0165/0165_0041.f90
+++ b/Fortran/0165/0165_0041.f90
@@ -2,14 +2,14 @@ i=10
 j=20
 k=30
          !$omp parallel default(none) private(i,j,k)
-         !$omp parallel do default(none) collapse(3_2) private(i,j,k) 
+         !$omp parallel do default(none) collapse(3_2) private(i)
          do i=1,1
            do j=1,1
            do k=1,1
            end do
            end do
          end do
-         !$omp parallel do default(none) collapse(3_2) private(i,j,k) 
+         !$omp parallel do default(none) collapse(3_2) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0538/0538_0031.f90
+++ b/Fortran/0538/0538_0031.f90
@@ -1,13 +1,13 @@
 ido1=1
 ido2=2
 !$omp parallel default(none) private(ido1,ido2)
-!$omp paralleldo 
+!$omp paralleldo shared(ido2)
 do ido1=1,10
 do ido2=1,10
 end do
 end do
 !$omp endparalleldo
-!$omp paralleldo private(ido1,ido2)
+!$omp paralleldo shared(ido1)
 do ido2=1,10
 do ido1=1,10
 end do

--- a/Fortran/0777/0777_0001.f90
+++ b/Fortran/0777/0777_0001.f90
@@ -1,7 +1,7 @@
 i=10
 j=20
 k=30
-         !$omp parallel do default(none) collapse(3) private(i) shared(j)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1

--- a/Fortran/0777/0777_0002.f90
+++ b/Fortran/0777/0777_0002.f90
@@ -2,7 +2,7 @@ i=10
 j=20
 k=30
          !$omp parallel default(none)
-         !$omp parallel do default(none) collapse(3) private(i) shared(j)
+         !$omp parallel do default(none) collapse(3) private(i)
          do i=1,1
            do j=1,1
            do k=1,1
@@ -19,11 +19,11 @@ i=10
 j=20
 k=30
          !$omp parallel default(none)
-         !$omp parallel default(none) private(i) shared(j)
+         !$omp parallel default(none) private(i)
          !$omp endparallel 
          !$omp endparallel
          !$omp parallel default(none)
-         !$omp parallel default(none) private(i) shared(j)
+         !$omp parallel default(none) private(i)
          !$omp do collapse(3)
          do i=1,1
            do j=1,1

--- a/Fortran/0842/0842_0001.f90
+++ b/Fortran/0842/0842_0001.f90
@@ -7,7 +7,7 @@ subroutine sub(a)
  b = b + a
  enddo
 !$omp endparallel
-!$omp  parallel do simd  shared(i)
+!$omp  parallel do simd
  do i=1,10
  b = b + a
  enddo

--- a/Fortran/0842/0842_0003.f90
+++ b/Fortran/0842/0842_0003.f90
@@ -1,4 +1,4 @@
- !$omp parallel do simd shared(j1) collapse(1)
+ !$omp parallel do simd collapse(1)
   do j1=1,10
    do j2=1,10
     do j3=1,10


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17297".
  https://linaro.atlassian.net/browse/LLVM-2214

Specifically, I make the following the correction.
・The SHARED attribute specified for the loop iteration variable is removed.
