### PR TITLE
Testset fixes based on LLVM-2221 and Workitem 17568

### DIFF
--- a/C/0022/0022_0039.c
+++ b/C/0022/0022_0039.c
@@ -32,7 +32,8 @@ int main() {
 
   // -fno-fast-math: 5.214844
   // -ffast-math: 5.167969
-  if (5.167968 <= out && out <= 5.214844)
+  // LLVM-2221: 5.164061
+  if (5.164061 <= out && out <= 5.214844)
     printf("OK\n");
   else
     printf("NG\n%f\n", (float)out);


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17568".
  https://linaro.atlassian.net/browse/LLVM-2221

Specifically, I will make the following correction.
The theoretical value of the calculation result is `5.166015625`. The lower limit of the evaluation threshold, `5.167968`, is set to exceed the theoretical value. The calculation result for this issue (`5.164062`) falls within `-1ULP` of the theoretical value in half-precision. Therefore, although the issue result is within `1ULP` of the theoretical value, it does not meet the evaluation criteria. (The theoretical value also falls outside the range.)

Based on the above, the threshold value in the IF statement is changed from `5.167968` to `5.164061`.
