### PR TITLE
Testset fixes based on LLVM-2228 and Workitem 17641

### DIFF
--- a/Fortran/0118/0118_0266.f90
+++ b/Fortran/0118/0118_0266.f90
@@ -94,10 +94,12 @@ real(4),dimension(1:4,1:3) :: x
 real(4),dimension(1:4,1:3) :: ans = reshape((/21.3899994_4, 29.3399982_4, 37.2900009_4, 45.2399979_4, 53.1899986_4, 67.8600006_4, 82.5300064_4, 97.1999969_4, 84.9900055_4, 106.379997_4, 127.769997_4, 149.160004_4/),(/4,3/))
 real(4),parameter :: error = 7.7E-06_4
 integer :: test_no
+real(4) :: err
 do j=1,3
    do i=1,4
-      if (abs(x(i,j)-ans(i,j)) .gt. error) then
-         print *,"test_no=",test_no,", ng: i=",i,": res=", x(i,j),"ans=",ans(i,j),abs(x(i,j)-ans(i,j)),error
+      err = merge(1.6E-05_4, error, (i == 4) .and. (j == 3))
+      if (abs(x(i,j)-ans(i,j)) .gt. err) then
+         print *,"test_no=",test_no,", ng: i=",i,": res=", x(i,j),"ans=",ans(i,j),abs(x(i,j)-ans(i,j)),err
          print *,x
          return
       endif


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17641".
  https://linaro.atlassian.net/browse/LLVM-2228

This test performs a float calculation and verifies that the difference between the calculation result and the reference value is within a specified tolerance. The difference of 1.5E-5 between the float calculation result and the reference value exceeds the specified tolerance of 7.7E-6. (The calculation result is within 1 ULP of the reference value.)

It is presumed that the verification conditions are set to match the output results of the previous execution environment, based on the comments within this test. The commit for this issue involves changes related to `vectorizeTree` that affect SIMD optimization. Consequently, the code generation path changes depending on this commit and the execution environment, resulting in an error that falls outside the acceptance criteria (within 1 ULP).

Therefore, I will correct the acceptance criteria used in this test.
