### PR TITLE
Testset fixes based on LLVM-2232 and Workitem 17806

### DIFF
--- a/C/0094/0094_0065.c
+++ b/C/0094/0094_0065.c
@@ -5,7 +5,11 @@
 jmp_buf env;
 long int j=9;
 long int s=0;
+#if defined(__aarch64__) || defined(__x86_64)
+int sub(volatile long int *k);
+#else
 int sub(long int *k);
+#endif
 int main( ) {
 #if defined(__aarch64__) || defined(__x86_64)
 volatile long int k=1;
@@ -22,7 +26,11 @@ long int k=1;
   sub(&k);
   printf("ng\n");
 }
+#if defined(__aarch64__) || defined(__x86_64)
+int sub(volatile long int *k) {
+#else
 int sub(long int *k) {
+#endif
   for (;s<j; s++) {
     if (s==8) longjmp(env,1);
     else {


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17806".
  https://linaro.atlassian.net/browse/LLVM-2232

Specifically, I will make the following correction.
This testset uses `setjmp` and `longjmp` to verify whether the value of variable `k` is preserved when returning via `longjmp`.
Since the `volatile` modifier for variable `k` does not match between the variable declaration and the `sub` function definition, it is believed that the value of `k` updated within the `sub` function was not reflected by the time the function returned to the `main` function, resulting in the value not being retrieved.
Additionally, it is believed that this issue became apparent because the commit for this issue changed the handling of `volatile` operations to "capture only the address, not the value."

Based on the above, I will correct the testset.
Add a branch for `__aarch64__` or `__x86_64`, and add the `volatile` keyword to the type of variable `k` in the sub function's prototype declaration and function definition.
