### PR TITLE
Testset fixes based on LLVM-2231-01 and Workitem 17908

### DIFF
--- a/C/0056/0056_0019.c
+++ b/C/0056/0056_0019.c
@@ -16,7 +16,7 @@ int main()
   int i,j;
 
   thread = it = MAX_NUM_THREADS;
-  memset(sb,' ',10*10);
+  memset(sb,' ',sizeof(sb));
 #ifdef _OPENMP
   thread = omp_get_max_threads();
   if (thread > MAX_NUM_THREADS) {
@@ -107,7 +107,7 @@ int main()
   }else{
     printf( "NG!  PRIVATE clause is not active!\n");
     printf( "     sa=%s\n",sa);
-    printf( "     sb=%s\n",sb);
+    printf( "     sb=%s\n",sb[0]);
   }
   exit (0) ;
 }


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17908".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
This issue reports a failure in an OpenMP test (0056_0019.c) where the program incorrectly outputs that the PRIVATE clause is not active.

The failure occurs only when the number of threads is 8 or fewer. Investigation shows that the root cause is not a compiler or OpenMP bug, but an error in the test program itself.

Specifically, a two-dimensional array (sb) is only partially initialized using memset, leaving some elements uninitialized. Later validation assumes the entire array has been initialized, causing the comparison check to fail and resulting in a false NG output.

Additionally, the test contains a formatting issue in printf that triggers a type mismatch warning.

The problem can be resolved by:
- Correctly initializing the entire array using sizeof(sb)
- Fixing the printf argument to use sb[0]
