### PR TITLE
Testset fixes based on LLVM-2231-07 and Workitem 17976

### DIFF
--- a/Fortran/1064/1064_0259.f90
+++ b/Fortran/1064/1064_0259.f90
@@ -57,7 +57,7 @@ if (abs(r04-121)>0.00001) print *,204
 if (abs(r21-144)>0.00001) print *,211,r21
 if (abs(r22-144)>0.00001) print *,212
 if (abs(r23-144)>0.00001) print *,213
-if (abs(r24-144)>0.00001) print *,214
+if (abs(r24-144)>0.000016) print *,214
 if (abs(c31%im-121)>0.00001) print *,231
 if (abs(c32%im-121)>0.00001) print *,232
 if (abs(c33%im-121)>0.00001) print *,233
@@ -65,7 +65,7 @@ if (abs(c34%im-121)>0.00001) print *,234
 if (abs(c41%im-144)>0.00001) print *,241
 if (abs(c42%im-144)>0.00001) print *,242
 if (abs(c43%im-144)>0.00001) print *,243
-if (abs(c44%im-144)>0.00001) print *,244
+if (abs(c44%im-144)>0.000016) print *,244
 end
 implicit complex(c)
 c11=(11,12)

--- a/Fortran/1064/1064_0260.f90
+++ b/Fortran/1064/1064_0260.f90
@@ -59,7 +59,7 @@ if (any(abs(r04-121)>0.00001)) print *,204
 if (any(abs(r21-144)>0.00001)) print *,211,r21
 if (any(abs(r22-144)>0.00001)) print *,212
 if (any(abs(r23-144)>0.00001)) print *,213
-if (any(abs(r24-144)>0.00001)) print *,214
+if (any(abs(r24-144)>0.000016)) print *,214
 if (any(abs(c31%im-121)>0.00001)) print *,231
 if (any(abs(c32%im-121)>0.00001)) print *,232
 if (any(abs(c33%im-121)>0.00001)) print *,233
@@ -67,7 +67,7 @@ if (any(abs(c34%im-121)>0.00001)) print *,234
 if (any(abs(c41%im-144)>0.00001)) print *,241
 if (any(abs(c42%im-144)>0.00001)) print *,242
 if (any(abs(c43%im-144)>0.00001)) print *,243
-if (any(abs(c44%im-144)>0.00001)) print *,244
+if (any(abs(c44%im-144)>0.000016)) print *,244
 end
 implicit complex(c)
 dimension c11(2),c99(2)


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17976".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
The failures occur in checks of exponentiation results.
The error is caused by the approximate implementation of exponentiation enabled by -ffast-math. The observed deviation is within 1 ULP of the mathematically expected result.
The same root cause applies to 1064_0260.f90. Although that test uses array variables, the failing locations and the observed error are identical.

The observed behavior is consistent with the optimization semantics of -ffast-math. The generated result remains within 1 ULP of the expected value, but the test uses a stricter tolerance (0.00001) than the actual error (1.5258789E-05).
Therefore, this appears to be a test-suite issue rather than a Flang correctness issue. Relaxing the tolerance to a value that accommodates a 1-ULP error resolves the failure.
