### PR TITLE
Testset fixes based on LLVM-2231-08 and Workitem 18011

### DIFF
--- a/Fortran/1070/1070_0713.F90
+++ b/Fortran/1070/1070_0713.F90
@@ -42,6 +42,7 @@ real(kind=8),dimension(1:n1) :: a
 real(kind=4) :: res
 res = 1._4
 !ocl nosimd
+!dir$ novector
 do i=1,n1
 a(i) = 2._8
 res = res * 2._4


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 18011".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
The test program depends on the Fujitsu-specific directive "!ocl nosimd" to disable vectorization.
Since Flang treats this directive as a comment, the loop is vectorized under -O3 -ffast-math, resulting in different floating-point reduction behavior and a test failure.

This is a test-suite issue rather than a Flang compiler defect. I will update the test by adding a Flang-recognized vectorization suppression directive (!dir$ novector).
