### PR TITLE
Testset fixes based on LLVM-2231-09 and Workitem 17949

### DIFF
--- a/Fortran/1071/1071_0000/CMakeLists.txt
+++ b/Fortran/1071/1071_0000/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0000)
-set_property(TARGET Fujitsu-Fortran-1071_0000 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0000 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0000 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0000 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")

--- a/Fortran/1071/1071_0001/CMakeLists.txt
+++ b/Fortran/1071/1071_0001/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0001)
-set_property(TARGET Fujitsu-Fortran-1071_0001 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0001 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0001 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0001 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")

--- a/Fortran/1071/1071_0002/CMakeLists.txt
+++ b/Fortran/1071/1071_0002/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0002)
-set_property(TARGET Fujitsu-Fortran-1071_0002 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0002 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0002 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0002 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")

--- a/Fortran/1071/1071_0003/CMakeLists.txt
+++ b/Fortran/1071/1071_0003/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0003)
-set_property(TARGET Fujitsu-Fortran-1071_0003 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0003 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0003 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0003 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")

--- a/Fortran/1071/1071_0004/CMakeLists.txt
+++ b/Fortran/1071/1071_0004/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0004)
-set_property(TARGET Fujitsu-Fortran-1071_0004 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0004 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0004 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0004 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")

--- a/Fortran/1071/1071_0011/CMakeLists.txt
+++ b/Fortran/1071/1071_0011/CMakeLists.txt
@@ -1,3 +1,3 @@
 llvm_multisource(Fujitsu-Fortran-1071_0011)
-set_property(TARGET Fujitsu-Fortran-1071_0011 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp")
-set_property(TARGET Fujitsu-Fortran-1071_0011 APPEND PROPERTY LINK_OPTIONS "-fopenmp")
+set_property(TARGET Fujitsu-Fortran-1071_0011 APPEND PROPERTY COMPILE_OPTIONS "-fopenmp;-Wl,-z,execstack")
+set_property(TARGET Fujitsu-Fortran-1071_0011 APPEND PROPERTY LINK_OPTIONS "-fopenmp;-Wl,-z,execstack")


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17949".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
The test passes an internal procedure through a procedure pointer, which causes Flang to generate a trampoline requiring an executable stack. Since the linker option `-Wl,-z,execstack` is not specified, linking fails with lld.
The same behavior is observed with gfortran and matches the documented behavior of Flang's internal procedure trampolines.
Therefore, this is not a Flang compiler bug. I will update the test case to explicitly enable executable stack support.
