### PR TITLE
Testset fixes based on LLVM-2231-10 and Workitem 17939

### DIFF
--- a/Fortran/0366/0366_0097.F
+++ b/Fortran/0366/0366_0097.F
@@ -12,13 +12,14 @@
 	parameter( y1 = 37502500.0 )
         parameter( x2 = 12502500.0 )
 	parameter( y2 = 37501328.0 )
+        parameter( epsilon = 4.0 )
 	a=1
 	call sub(loc(a),n-1)
 	if( sum(a(1:n/2)) /= x1 .and. sum(a(1:n/2)) /= x2 ) then
            print *,"NG1"
         endif
         res = sum(a(n/2+1:n),mask=.TRUE.);
-	if( res /= y1 .and. res /= y2 ) then
+        if( abs(res - y1) > epsilon .and. res /= y2 ) then
           print *,"NG2"
         endif
 	print *,"PASS"


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17939".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
This test checks that the sum of the second half of the array (a(5001:10000)) is:
  1  37502500.0
The generated SVE reduction code changes according to the value specified by -msve-vector-bits.
For -msve-vector-bits=512, the result is:
  1  37502496.0
which differs from the expected value by only 4.
This difference can be explained by a different accumulation order in the floating-point reduction.
Since floating-point addition is not associative, changing the SVE reduction tree may produce a result that differs by approximately one ULP.
Therefore, the observed result for -msve-vector-bits=512 is considered a floating-point accuracy difference rather than a compiler correctness issue.

I will modify the test to allow a small tolerance corresponding to the expected floating-point reduction error.

For example:
  1  parameter( epsilon = 4.0 )
  2
  3  if( abs(res - y1) > epsilon ) then
  4    print *,"NG2"
  5  endif

This change allows a ±1 ULP difference caused by changes in the reduction order while still detecting significant errors.
