### PR TITLE
Testset fixes based on LLVM-2231-11 and Workitem 17781

### DIFF
--- a/C/0096/0096_0118.c
+++ b/C/0096/0096_0118.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 

--- a/C/0096/0096_0120.c
+++ b/C/0096/0096_0120.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0122.c
+++ b/C/0096/0096_0122.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0124.c
+++ b/C/0096/0096_0124.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 

--- a/C/0096/0096_0126.c
+++ b/C/0096/0096_0126.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0128.c
+++ b/C/0096/0096_0128.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0129.c
+++ b/C/0096/0096_0129.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 

--- a/C/0096/0096_0130.c
+++ b/C/0096/0096_0130.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0131.c
+++ b/C/0096/0096_0131.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0132.c
+++ b/C/0096/0096_0132.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0133.c
+++ b/C/0096/0096_0133.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1

--- a/C/0096/0096_0135.c
+++ b/C/0096/0096_0135.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 

--- a/C/0096/0096_0137.c
+++ b/C/0096/0096_0137.c
@@ -1,7 +1,7 @@
 
 #include <stdio.h>
 
-#define LOOP_CONST 64 
+#define LOOP_CONST 50
 #define TRUE_RES 1
 #define FALSE_RES 0
 #define IF_RES 1


### PR DESCRIPTION
I will correct the testset based on the following Jira Card and "Workitem 17781".
  https://linaro.atlassian.net/browse/LLVM-2231

Specifically, I will make the following correction.
The issue is caused by excessively large array declarations on the stack within the test_loop_no_escape_pt1_LD function.
Specifically, d_data1 and d_data2 are declared as test_type d_data1[LOOP_CONST][LOOP_CONST][LOOP_CONST]; where LOOP_CONST is defined as 64. This results in a significant stack allocation.

For the reasons stated above, I will make the following corrections.
I will change the definition of LOOP_CONST in the test file from 64 to 50.
Note: This directly addresses the root cause of the stack overflow.
