### PR TITLE
Testset fixes based on LLVM-2242 and Workitem 18320

### DIFF
--- a/Fortran/0688/0688_0014.f90
+++ b/Fortran/0688/0688_0014.f90
@@ -3,6 +3,7 @@ subroutine sub1()
   integer,save::ta1,ta2
   real(8)::b(10)
   real(8),save::tb1(10),tb2(10)
+  integer(8), save :: pa,pb
   pointer(pa, a)
   pointer(pb, b)
   ta1=1

--- a/Fortran/0688/0688_0016.f90
+++ b/Fortran/0688/0688_0016.f90
@@ -3,6 +3,7 @@ subroutine sub1()
   integer,save::ta0,ta1,ta2
   real(8)::b(10)
   real(8),save::tb0(10),tb1(10),tb2(10)
+  integer(8), save :: pa,pb
   pointer(pa, a)
   pointer(pb, b)
   ta0=1


### PR DESCRIPTION
I will correct the testsets based on the following Jira Card and "Workitem 18320".
  https://linaro.atlassian.net/browse/LLVM-2242

Specifically, I will make the following correction.
Cray pointer variables (pa, pb) are specified in the lastprivate clause of an OpenMP sections construct.
However, these variables are treated as private in the enclosing context, which violates OpenMP requirements.

According to the OpenMP specification, a variable listed in a lastprivate clause must not be private in the enclosing parallel context.
In this test case:
 - pa and pb are local Cray pointer variables
 - They are implicitly private in the outer context
 - Therefore, their use in lastprivate violates the specification

I modify the testsets to satisfy the OpenMP requirements.
  Example fix:
    integer(8), save :: pa,pb
Adding the SAVE attribute ensures that pa and pb are treated as shared in the enclosing context.
