### PR TITLE
Testset fixes based on LLVM-2243 and Workitem 18335

### DIFF
--- a/Fortran/0289/0289_0025.f
+++ b/Fortran/0289/0289_0025.f
@@ -42,7 +42,7 @@
       data   (a(i),i=1,10)/1*9.,2*9.,3*9.,4*9./
       data   (b(i),i=1,10)/4*9.,3*9.,2*9.,1*9./
       logical lscmp
-      lscmp(a,b)=a.ne.b .or. a.ne.0. .or. b.ne.0.
+      lscmp(x,y)=x.ne.y .or. x.ne.0. .or. y.ne.0.
       do 10 i=1,10
        call sub1(a,b,i)
    10  continue

--- a/Fortran/0572/0572_0463.f90
+++ b/Fortran/0572/0572_0463.f90
@@ -4,8 +4,9 @@ call sub(d)
 contains
 subroutine sub(c)
 complex ::c(..),c2=0
+complex ::x
 real :: sfun1,x1    
-sfun1(c) = range(c)
+sfun1(x) = range(x)
 x1=sfun1(c2)
 if(x1 /= 37.0000)print*,101
 print*,"pass"


### PR DESCRIPTION
I will correct the testsets based on the following Jira Card and "Workitem 18335".
  https://linaro.atlassian.net/browse/LLVM-2243

Specifically, I will make the following correction.
The tests fail due to compilation errors after stricter semantic checks were introduced for statement function argument names.
The tests incorrectly use statement function dummy argument names (e.g., a, b) that conflict with already declared array variables in the same scope.
  - In 0289_0025.f, statement function lscmp(a,b) conflicts with arrays a(10) and b(10)
  - In 0572_0463.f90, similar conflict occurs with dummy argument name reuse

I rename statement function dummy arguments to avoid conflicts (e.g., a,b → x,y).
  - lscmp(a,b)=a.ne.b .or. a.ne.0. .or. b.ne.0.
  + lscmp(x,y)=x.ne.y .or. x.ne.0. .or. y.ne.0.
