### PR TITLE
Testset fixes based on Workitem 16928 (for GCC)

### DIFF
--- a/C/0178/0178_0012/0178_0012_0000.c
+++ b/C/0178/0178_0012/0178_0012_0000.c
@@ -81,7 +81,7 @@ void test_ex2()
 	printf("\t After test_ex2 int_var=%d\n", 2);
 }
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(__clang__)
 __attribute((const)) void test_ex3()
 {
 	int_var = 1;


### PR DESCRIPTION
I will correct the testset based on the following "Workitem 16928".

Specifically, I will make the following correction.
When compiling 0178_0012_0000.c and 0178_0012_0001.c with GCC using -O3 -ffast-math, functions test_ex3() through test_ex7() are not executed.
The affected functions are declared with __attribute__((const)) or __attribute__((pure)), but their implementations perform operations that violate the requirements of these attributes, including modification of a global variable, calls to printf(), and invocation of a non-const function.
GCC performs optimizations based on the specified attributes and removes the calls. As a result, the behavior differs from Clang/LLVM, where test_ex3() through test_ex7() are executed.

Based on the above, the following corrections will be made.
Disable the const attribute for GCC builds and retain it only for Clang builds.
    1  -#if defined(__aarch64__)
    2  +#if defined(__aarch64__) && defined(__clang__)
    3   __attribute((const)) void test_ex3()
This avoids optimization differences between GCC and Clang and allows all test cases to execute.
