### PR TITLE
Testset fixes based on Workitem 16931 (for GCC)

### DIFF
--- a/C++/0005/0005_0045.cc
+++ b/C++/0005/0005_0045.cc
@@ -128,7 +128,7 @@ void sub15( int a, ...)
   va_list ap;
 
   va_start( ap , a );
-  va_arg( ap , enum E1 );
+  va_arg( ap , int );
 }
 
 void sub16( int a, ...)

--- a/C++/0027/0027_0026.cc
+++ b/C++/0027/0027_0026.cc
@@ -20,23 +20,23 @@ template <class T> T loop_fusion_for_va(T *p, int n, ...) {
 }
 
 int main() {
-  char ca[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  short sa[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  int ca[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  int sa[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   int ia[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   long long lla[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  unsigned char uca[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  unsigned short usa[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  unsigned int uca[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  unsigned int usa[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   unsigned ua[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   unsigned long long ulla[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   int res = 0;
-  res = (int)loop_fusion_for_va(ca, (char)10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
-  res += (int)loop_fusion_for_va(sa, (short)10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+  res = (int)loop_fusion_for_va(ca, (int)10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+  res += (int)loop_fusion_for_va(sa, (int)10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
   res += (int)loop_fusion_for_va(ia, (int)10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
   res += (int)loop_fusion_for_va(lla, (long long)10, 1LL, 1LL, 1LL, 1LL, 1LL,
                                  1LL, 1LL, 1LL, 1LL, 1LL);
-  res += (int)loop_fusion_for_va(uca, (unsigned char)10, 1, 1, 1, 1, 1, 1, 1, 1,
+  res += (int)loop_fusion_for_va(uca, (unsigned int)10, 1, 1, 1, 1, 1, 1, 1, 1,
                                  1, 1);
-  res += (int)loop_fusion_for_va(usa, (unsigned short)10, 1, 1, 1, 1, 1, 1, 1,
+  res += (int)loop_fusion_for_va(usa, (unsigned int)10, 1, 1, 1, 1, 1, 1, 1,
                                  1, 1, 1);
   res += (int)loop_fusion_for_va(ua, (unsigned int)10, 1U, 1U, 1U, 1U, 1U, 1U,
                                  1U, 1U, 1U, 1U);

--- a/C/0024/0024_0001.c
+++ b/C/0024/0024_0001.c
@@ -22,7 +22,7 @@ short int sum1(short int num, ...){
 
   va_start(argptr, num);
   for( ; num > 0; num--){
-    ans += va_arg(argptr,signed short int);
+    ans += va_arg(argptr,int);
   }
 
   va_end(argptr);
@@ -35,7 +35,7 @@ short int sum2(short int num, ...){
 
   va_start(argptr, num);
   for( ; num > 0; num--){
-    ans += (int)va_arg(argptr,float);
+    ans += (int)va_arg(argptr,double);
   }
 
   va_end(argptr);

--- a/C/0172/0172_0000.c
+++ b/C/0172/0172_0000.c
@@ -22,7 +22,7 @@ short int sum1(short int num, ...){
 
   va_start(argptr, num);
   for( ; num > 0; num--){
-    ans += va_arg(argptr,signed short int);
+    ans += va_arg(argptr,signed int);
   }
 
   va_end(argptr);
@@ -35,7 +35,7 @@ short int sum2(short int num, ...){
 
   va_start(argptr, num);
   for( ; num > 0; num--){
-    ans += (int)va_arg(argptr,float);
+    ans += (int)va_arg(argptr,double);
   }
 
   va_end(argptr);

--- a/C/0172/0172_0002.c
+++ b/C/0172/0172_0002.c
@@ -34,7 +34,7 @@ void foo4(int i, ...)
 {
   va_list ap;
   va_start(ap,i);
-  if(((float)va_arg(ap, short))==2.0 )
+  if(((float)va_arg(ap, int))==2.0 )
     puts("ok");
   else
     puts("ng");
@@ -44,7 +44,7 @@ void foo5(int i, ...)
 {
   va_list ap;
   va_start(ap,i);
-  if(((double)va_arg(ap, short))==2.0 )
+  if(((double)va_arg(ap, int))==2.0 )
     puts("ok");
   else
     puts("ng");
@@ -54,7 +54,7 @@ void foo6(int i, ...)
 {
   va_list ap;
   va_start(ap,i);
-  if(((long double)va_arg(ap, short))==2.0 )
+  if(((long double)va_arg(ap, int))==2.0 )
     puts("ok");
   else
     puts("ng");
@@ -64,7 +64,7 @@ void foo7(int i, ...)
 {
   va_list ap;
   va_start(ap,i);
-  if(((long double)va_arg(ap, char))==2.0 )
+  if(((long double)va_arg(ap, int))==2.0 )
     puts("ok");
   else
     puts("ng");


### PR DESCRIPTION
I will correct the testset based on the following "Workitem 16931".

Specifically, I will make the following correction.
The runtime abort is caused by undefined behavior resulting from incorrect use of va_arg() with variadic arguments that undergo default argument promotion. Updating the test case to retrieve int and double instead of short and float resolves the issue.
