### PR TITLE
Suppress reference output lookup for C++ tests

### DIFF
--- a/C++/cxx17/CMakeLists.txt
+++ b/C++/cxx17/CMakeLists.txt
@@ -42,4 +42,7 @@ endforeach()
 
 set(Source ${cxx17_sources})
 
+# Do not look for reference output files.
+set(NO_REFERENCE_OUTPUT 1)
+
 llvm_singlesource_fujitsu(PREFIX "Fujitsu-C++-")

--- a/C++/cxx20/CMakeLists.txt
+++ b/C++/cxx20/CMakeLists.txt
@@ -53,4 +53,7 @@ endforeach()
 
 set(Source ${cxx20_sources})
 
+# Do not look for reference output files.
+set(NO_REFERENCE_OUTPUT 1)
+
 llvm_singlesource_fujitsu(PREFIX "Fujitsu-C++-")

--- a/C++/cxx23/CMakeLists.txt
+++ b/C++/cxx23/CMakeLists.txt
@@ -9,4 +9,7 @@ endforeach()
 
 set(Source ${cxx23_sources})
 
+# Do not look for reference output files.
+set(NO_REFERENCE_OUTPUT 1)
+
 llvm_singlesource_fujitsu(PREFIX "Fujitsu-C++-")


### PR DESCRIPTION
Add NO_REFERENCE_OUTPUT to the C++17, C++20, and C++23 test directories to suppress unnecessary reference output lookup messages for tests that determine success by the return value of main().

Validation:

CMake configuration: successful

Ninja build: 184/184 successful

C++17 lit tests: 34/34 passed

C++20 lit tests: 45/45 passed

C++23 lit tests: 1/1 passed