### PR TITLE
Testset fixes based on Workitem 17093 (for GCC)

### DIFF
--- a/C/0113/CMakeLists.txt
+++ b/C/0113/CMakeLists.txt
@@ -26,5 +26,7 @@ set_property(SOURCE 0113_0079.c APPEND PROPERTY COMPILE_OPTIONS "-ffast-math;-fn
 set_property(TARGET Fujitsu-C-0113_0079 APPEND PROPERTY LINK_OPTIONS "-ffast-math")
 set_property(SOURCE 0113_0080.c APPEND PROPERTY COMPILE_OPTIONS "-ffast-math;-fno-inline-functions")
 set_property(TARGET Fujitsu-C-0113_0080 APPEND PROPERTY LINK_OPTIONS "-ffast-math")
+set_property(SOURCE 0113_0098.c APPEND PROPERTY COMPILE_OPTIONS "-fno-strict-aliasing")
+set_property(SOURCE 0113_0107.c APPEND PROPERTY COMPILE_OPTIONS "-fno-strict-aliasing")
 set_property(SOURCE 0113_0109.c APPEND PROPERTY COMPILE_OPTIONS "-fsigned-char")
 set_property(SOURCE 0113_0116.c APPEND PROPERTY COMPILE_OPTIONS "-fno-inline-functions")


### PR DESCRIPTION
I will correct the testset based on "Workitem 17093".

Specifically, I will make the following correction.
This issue is not a compiler defect. It is caused by code that violates the strict aliasing rules by accessing the same union storage through pointers of different types.
When optimization levels such as -O2, -O3, or -Os are used, -fstrict-aliasing is enabled. Under these conditions, the compiler is allowed to assume that struct tag * and int * do not refer to the same object, and performs optimizations based on that assumption. Consequently, the store through int * is not considered to affect the value accessed through struct tag *, resulting in the observed difference from the expected behavior.
As a workaround, use the -fno-strict-aliasing option to disable optimizations based on strict aliasing assumptions.
