### PR TITLE
Testset fixes based on Workitem 17182 (for GCC)

### DIFF
--- a/C/0094/0094_0049.c
+++ b/C/0094/0094_0049.c
@@ -8,7 +8,7 @@ typedef struct s1{
 		double	a;
 		short	b;
 		}c;
-	char	d[5];
+	char	d[6];
 	struct	s2{
 		union u2{
 			float	a;
@@ -19,7 +19,7 @@ typedef struct s1{
 					short	a;
 					long	b;
 					}b;
-				char c[10];
+				char c[11];
 				}c;
 			}a;
 		short b;

--- a/C/0129/0129_0040.c
+++ b/C/0129/0129_0040.c
@@ -10,7 +10,7 @@ typedef struct s1{
 		double	a;
 		short	b;
 		}c;
-	char	d[5];
+	char	d[6];
 	struct	s2{
 		union u2{
 			float	a;
@@ -21,7 +21,7 @@ typedef struct s1{
 					short	a;
 					long	b;
 					}b;
-				char c[10];
+				char c[11];
 				}c;
 			}a;
 		short b;


### PR DESCRIPTION
I will correct the testset based on "Workitem 17182".

Specifically, I will make the following correction.
This issue is caused by a defect in the test program rather than a compiler problem.
The unexpected output results from a buffer overflow triggered by copying a six-byte string (including the null terminator) into a five-byte character array.

Based on the above, I will modify the test program so that the destination buffer can store both character data and the terminating null character.
