### PR TITLE
Testset fixes based on Workitem 17419 (for GCC)

### DIFF
--- a/C/0011/0011_0161.c
+++ b/C/0011/0011_0161.c
@@ -1,4 +1,5 @@
 #include  <stdio.h>
+#include  <string.h>
 
 int main()
 {
@@ -7,6 +8,8 @@ union {
       int  b ;
       int  c[5] ;
       } x = { 'a' } ;
+  memset(&x, 0x00, sizeof(x));
+  x.a = 'a';
   printf("********** TEST START **********\n");
 
   if (x.a=='a' && x.c[1] == 0)


### PR DESCRIPTION
I will correct the testset based on "Workitem 17419".

Specifically, I will make the following correction.
The failure is caused by the test program relying on unspecified values from inactive union storage.
This is not a compiler issue. Updating the test to initialize the entire union object resolves the problem.
