### PR TITLE
Testset fixes based on Workitem 17517 (for GCC)

### DIFF
--- a/C++/0000/0000_0058.cpp
+++ b/C++/0000/0000_0058.cpp
@@ -25,8 +25,9 @@ bool S::action() {
   }
   
   for (int i=0; i<vec1.size(); ++i) {
+    int tmp = vec1[i];
     func1();
-    m += vec1[i];
+    m += tmp;
   }
   if (m != Answer) {
     flg = true;

--- a/C++/0018/0018_0135.cpp
+++ b/C++/0018/0018_0135.cpp
@@ -2,5 +2,5 @@
 
 int main() {
     std::vector<int> v1(100);
-    v1[200];
+    v1[99];
 }


### PR DESCRIPTION
I will correct the testset based on "Workitem 17517".

Specifically, I will make the following correction.
This is not a compiler or standard library defect. The assertion failure is caused by undefined behavior in the application code due to an out-of-bounds access on an empty `std::vector` after clear().

Based on the above, I will modify the code so that, after `vec1.clear()`, I save the elements to `tmp` before calling `clear()` to ensure that `vec1[i]` is not referenced.
