### PR TITLE
Testset fixes based on Workitem 17529 (for GCC)

### DIFF
--- a/C++/0018/0018_0123.cpp
+++ b/C++/0018/0018_0123.cpp
@@ -5,6 +5,7 @@
 
 int main() {
     std::list<int> l;
+    l.push_back(0);
     l.back();
 }
 

--- a/C++/0018/0018_0124.cpp
+++ b/C++/0018/0018_0124.cpp
@@ -5,6 +5,7 @@
 
 int main() {
     std::list<int> l;
+    l.push_back(0);
     l.front();
 }
 


### PR DESCRIPTION
I will correct the testset based on "Workitem 17529".

Specifically, I will make the following correction.
This is not a compiler or standard library defect.
The failure is caused by application code that calls `std::list::back()` on an empty container.
Since accessing a non-existent element results in undefined behavior, the assertion failure observed in libstdc++ is expected.

Based on the above, I will modify the code to add elements before calling `back()`.
