### PR TITLE
Testset fixes based on Workitem 17576 (for GCC)

### DIFF
--- a/C++/0018/0018_0352.cpp
+++ b/C++/0018/0018_0352.cpp
@@ -9,7 +9,7 @@ int main()
 
     {
         typedef std::bernoulli_distribution D;
-        D d(2);
-        assert(d.p() == 2);
+        D d(0.75);
+        assert(d.p() == 0.75);
     }
 }

--- a/C++/0018/0018_0364.cpp
+++ b/C++/0018/0018_0364.cpp
@@ -8,15 +8,15 @@ int main()
 {
     {
         typedef std::binomial_distribution<> D;
-        D d(3, 2); 
+        D d(3, 0.5);
         assert(d.t() == 3);
-        assert(d.p() == 2);
+        assert(d.p() == 0.5);
     }
 	
 	{
         typedef std::binomial_distribution<> D;
-        D d(-1, 0.75); 
-        assert(d.t() == -1);
+        D d(1, 0.75);
+        assert(d.t() == 1);
         assert(d.p() == 0.75);
     }
 }

--- a/C++/0018/0018_0376.cpp
+++ b/C++/0018/0018_0376.cpp
@@ -8,6 +8,6 @@
 int main()
 {
     typedef std::geometric_distribution<> D;
-    D d(3);
-    assert(d.p() == 3);
+    D d(0.3);
+    assert(d.p() == 0.3);
 }

--- a/C++/0018/0018_0388.cpp
+++ b/C++/0018/0018_0388.cpp
@@ -8,15 +8,15 @@ int main()
 {
     {
         typedef std::negative_binomial_distribution<> D;
-        D d(-1, 0.75); 
-        assert(d.k() == -1);
+        D d(1, 0.75);
+        assert(d.k() == 1);
         assert(d.p() == 0.75);
     }
 	
 	{
         typedef std::negative_binomial_distribution<> D;
-        D d(3, -1); 
+        D d(3, 1);
         assert(d.k() == 3);
-        assert(d.p() == -1);
+        assert(d.p() == 1);
     }
 }

--- a/C++/0018/0018_0412.cpp
+++ b/C++/0018/0018_0412.cpp
@@ -8,6 +8,6 @@
 int main()
 {
     typedef std::chi_squared_distribution<> D;
-    D d(-14.5);
-    assert(d.n() == -14.5);
+    D d(14.5);
+    assert(d.n() == 14.5);
 }

--- a/C++/0018/0018_0424.cpp
+++ b/C++/0018/0018_0424.cpp
@@ -9,8 +9,8 @@ int main()
 {
     {
         typedef std::fisher_f_distribution<> D;
-        D d(-14.5, -5.25);
-        assert(d.m() == -14.5);
-        assert(d.n() == -5.25);
+        D d(14.5, 5.25);
+        assert(d.m() == 14.5);
+        assert(d.n() == 5.25);
     }
 }

--- a/C++/0018/0018_0446.cpp
+++ b/C++/0018/0018_0446.cpp
@@ -8,7 +8,7 @@
 int main()
 {
     typedef std::normal_distribution<> D;
-    D d(14.5, -5.25);
+    D d(14.5, 5.25);
     assert(d.mean() == 14.5);
-    assert(d.stddev() == -5.25);
+    assert(d.stddev() == 5.25);
 }

--- a/C++/0018/0018_0457.cpp
+++ b/C++/0018/0018_0457.cpp
@@ -9,7 +9,7 @@ int main()
 {
     {
         typedef std::student_t_distribution<> D;
-        D d(-14.5);
-        assert(d.n() == -14.5);
+        D d(14.5);
+        assert(d.n() == 14.5);
     }
 }

--- a/C++/0018/0018_0468.cpp
+++ b/C++/0018/0018_0468.cpp
@@ -6,6 +6,6 @@
 int main()
 {
     typedef std::exponential_distribution<> D;
-    D d(-106);
-    assert(d.lambda() == -106);
+    D d(106);
+    assert(d.lambda() == 106);
 }

--- a/C++/0018/0018_0490.cpp
+++ b/C++/0018/0018_0490.cpp
@@ -9,15 +9,15 @@ int main()
 {
     {
         typedef std::gamma_distribution<> D;
-        D d(-1, 5.25);
-        assert(d.alpha() == -1); 
+        D d(1, 5.25);
+        assert(d.alpha() == 1);
         assert(d.beta() == 5.25);
     }
 	
 	{
         typedef std::gamma_distribution<> D;
-        D d(0.25, -2);
-        assert(d.alpha() == 0.25); 
-        assert(d.beta() == -2);
+        D d(0.25, 2);
+        assert(d.alpha() == 0.25);
+        assert(d.beta() == 2);
     }
 }

--- a/C++/0018/0018_0502.cpp
+++ b/C++/0018/0018_0502.cpp
@@ -8,6 +8,6 @@
 int main()
 {
     typedef std::poisson_distribution<> D;
-    D d(-2);
-    assert(d.mean() == -2);
+    D d(2);
+    assert(d.mean() == 2);
 }

--- a/C++/0018/0018_0549.cpp
+++ b/C++/0018/0018_0549.cpp
@@ -10,8 +10,8 @@ int main()
 {
     {
         typedef std::uniform_int_distribution<> D;
-        D d(100, 10);
-        assert(d.a() == 100);
-        assert(d.b() == 10);
+        D d(10, 100);
+        assert(d.a() == 10);
+        assert(d.b() == 100);
     }
 }

--- a/C++/0018/0018_0561.cpp
+++ b/C++/0018/0018_0561.cpp
@@ -11,9 +11,9 @@ int main()
     {
         typedef std::uniform_real_distribution<> D;
 		typedef D::result_type RealType;
-        D d(106, 6); 
-        assert(d.a() == 106);
-        assert(d.b() == 6);
+        D d(6, 106);
+        assert(d.a() == 6);
+        assert(d.b() == 106);
     }
 	
 	{


### PR DESCRIPTION
I will correct the testset based on "Workitem 17576".

Specifically, I will make the following correction.
This is not a compiler or standard library defect.
The assertion failure is caused by application code that passes an invalid parameter value to std::bernoulli_distribution, violating the standard-defined precondition 0 ≤ p ≤ 1.
The runtime assertion in libstdc++ is an expected consequence of detecting this precondition violation.

Based on the above, I will adjust the probability parameters so that they satisfy the preconditions.
