### PR TITLE
Add C++23 if consteval test program

### DIFF
--- a/C++/cxx23/CMakeLists.txt
+++ b/C++/cxx23/CMakeLists.txt
@@ -2,6 +2,7 @@ set(cxx23_sources
     size_t_literal_suffix.cpp
     lambda_optional_parens.cpp
     simpler_implicit_move.cpp
+    if_consteval.cpp
 )
 
 foreach(src ${cxx23_sources})

--- a/C++/cxx23/if_consteval.cpp
+++ b/C++/cxx23/if_consteval.cpp
@@ -1,0 +1,79 @@
+/*
+FEATURE: if consteval
+SPEC: P1938R3
+PURPOSE: Verify that if consteval and if ! consteval select the correct branches during constant evaluation and runtime evaluation.
+RUN: clang++ -std=c++23 -Wall -Wextra -Werror if_consteval.cpp
+*/
+
+#include <cstdlib>
+
+consteval int immediate_double(int value)
+{
+    return value * 2;
+}
+
+constexpr int select_evaluation_path(int value)
+{
+    // Verify if consteval selects the compile-time branch.
+    if consteval {
+        return immediate_double(value);
+    } else {
+        return value + 1;
+    }
+}
+
+constexpr int select_inverted_path(int value)
+{
+    // Verify if ! consteval selects the runtime branch.
+    if ! consteval {
+        return value - 1;
+    } else {
+        return immediate_double(value);
+    }
+}
+
+constexpr int select_without_else(int value)
+{
+    // Verify if consteval without else executes only during constant evaluation.
+    if consteval {
+        value += 100;
+    }
+
+    return value;
+}
+
+int main()
+{
+    // Verify compile-time selection with if consteval.
+    constexpr int compile_time_result = select_evaluation_path(10);
+    static_assert(compile_time_result == 20);
+
+    // Verify compile-time selection with if ! consteval.
+    constexpr int compile_time_inverted = select_inverted_path(20);
+    static_assert(compile_time_inverted == 40);
+
+    // Verify compile-time execution of if consteval without else.
+    constexpr int compile_time_no_else = select_without_else(30);
+    static_assert(compile_time_no_else == 130);
+
+    // Verify runtime selection of the else branch.
+    const int runtime_result = select_evaluation_path(10);
+    if (runtime_result != 11) {
+        return EXIT_FAILURE;
+    }
+
+    // Verify runtime selection of the if ! consteval branch.
+    const int runtime_inverted = select_inverted_path(20);
+    if (runtime_inverted != 19) {
+        return EXIT_FAILURE;
+    }
+
+    // Verify runtime execution skips the if consteval block.
+    const int runtime_no_else = select_without_else(30);
+    if (runtime_no_else != 30) {
+        return EXIT_FAILURE;
+    }
+
+    // Verify successful completion of all checks.
+    return EXIT_SUCCESS;
+}

--- a/C++/cxx23/if_consteval.cpp
+++ b/C++/cxx23/if_consteval.cpp
@@ -7,14 +7,15 @@ RUN: clang++ -std=c++23 -Wall -Wextra -Werror if_consteval.cpp
 
 #include <cstdlib>
 
+// Immediate function used by consteval branches.
 consteval int immediate_double(int value)
 {
     return value * 2;
 }
 
+// Verify that if consteval selects different paths depending on evaluation context.
 constexpr int select_evaluation_path(int value)
 {
-    // Verify if consteval selects the compile-time branch.
     if consteval {
         return immediate_double(value);
     } else {
@@ -22,9 +23,9 @@ constexpr int select_evaluation_path(int value)
     }
 }
 
+// Verify that if ! consteval inverts the compile-time/runtime selection.
 constexpr int select_inverted_path(int value)
 {
-    // Verify if ! consteval selects the runtime branch.
     if ! consteval {
         return value - 1;
     } else {
@@ -32,9 +33,9 @@ constexpr int select_inverted_path(int value)
     }
 }
 
+// Verify that if consteval without an else branch executes only during constant evaluation.
 constexpr int select_without_else(int value)
 {
-    // Verify if consteval without else executes only during constant evaluation.
     if consteval {
         value += 100;
     }
@@ -44,36 +45,40 @@ constexpr int select_without_else(int value)
 
 int main()
 {
-    // Verify compile-time selection with if consteval.
+    // Verify compile-time selection of the if consteval branch.
     constexpr int compile_time_result = select_evaluation_path(10);
     static_assert(compile_time_result == 20);
 
-    // Verify compile-time selection with if ! consteval.
+    // Verify compile-time selection of the else branch of if ! consteval.
     constexpr int compile_time_inverted = select_inverted_path(20);
     static_assert(compile_time_inverted == 40);
 
-    // Verify compile-time execution of if consteval without else.
+    // Verify compile-time execution of if consteval without an else branch.
     constexpr int compile_time_no_else = select_without_else(30);
     static_assert(compile_time_no_else == 130);
 
-    // Verify runtime selection of the else branch.
-    const int runtime_result = select_evaluation_path(10);
+    // Verify runtime selection of the else branch of if consteval.
+    int runtime_input1 = 10;
+    const int runtime_result = select_evaluation_path(runtime_input1);
     if (runtime_result != 11) {
         return EXIT_FAILURE;
     }
 
     // Verify runtime selection of the if ! consteval branch.
-    const int runtime_inverted = select_inverted_path(20);
+    int runtime_input2 = 20;
+    const int runtime_inverted = select_inverted_path(runtime_input2);
     if (runtime_inverted != 19) {
         return EXIT_FAILURE;
     }
 
-    // Verify runtime execution skips the if consteval block.
-    const int runtime_no_else = select_without_else(30);
+    // Verify that the if consteval block is skipped during runtime evaluation.
+    int runtime_input3 = 30;
+    const int runtime_no_else = select_without_else(runtime_input3);
     if (runtime_no_else != 30) {
         return EXIT_FAILURE;
     }
 
-    // Verify successful completion of all checks.
+    // All compile-time and runtime checks succeeded.
     return EXIT_SUCCESS;
 }
+


### PR DESCRIPTION
## Summary

Add a C++23 language feature test for P1938R3 (if consteval).

The test verifies:

- if consteval
- if ! consteval
- consteval function invocation
- constant evaluation path
- runtime evaluation path

## Verification

- Build completed successfully with CMake/Ninja
- lit test passed
- GCC verification completed